### PR TITLE
feat: Allow serialization/deserialization of arbitrary CAR headers

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -1,3 +1,4 @@
+use std::{collections::TryReserveError, convert::Infallible};
 use thiserror::Error;
 
 /// Car utility error
@@ -24,5 +25,17 @@ impl From<cid::Error> for Error {
 impl From<cid::multihash::Error> for Error {
     fn from(err: cid::multihash::Error) -> Error {
         Error::Parsing(err.to_string())
+    }
+}
+
+impl From<serde_ipld_dagcbor::error::DecodeError<Infallible>> for Error {
+    fn from(err: serde_ipld_dagcbor::error::DecodeError<Infallible>) -> Error {
+        Error::Cbor(err.into())
+    }
+}
+
+impl From<serde_ipld_dagcbor::error::EncodeError<TryReserveError>> for Error {
+    fn from(err: serde_ipld_dagcbor::error::EncodeError<TryReserveError>) -> Error {
+        Error::Cbor(err.into())
     }
 }

--- a/src/header.rs
+++ b/src/header.rs
@@ -54,6 +54,27 @@ impl CarHeader {
     }
 }
 
+impl Serialize for CarHeader {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            CarHeader::V1(header) => header.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for CarHeader {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let header = CarHeaderV1::deserialize(deserializer)?;
+        Ok(CarHeader::V1(header))
+    }
+}
+
 /// CAR file header version 1.
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
 pub struct CarHeaderV1 {

--- a/src/util.rs
+++ b/src/util.rs
@@ -7,6 +7,11 @@ use super::error::Error;
 /// Maximum size that is used for single node.
 pub(crate) const MAX_ALLOC: usize = 4 * 1024 * 1024;
 
+/// Read block of length described by varint leading bytes, returning a buffer slice containing
+/// the data portion of the block.
+///
+/// Returns a result for the buffer slice containing the data portion of the block, or `Ok(None)`
+/// if block does not begin with a valid varint.
 pub(crate) async fn ld_read<R>(mut reader: R, buf: &mut Vec<u8>) -> Result<Option<&[u8]>, Error>
 where
     R: AsyncRead + Unpin,

--- a/tests/car_file_test.rs
+++ b/tests/car_file_test.rs
@@ -17,7 +17,7 @@ async fn roundtrip_carv1_test_file() {
     let buf_reader = BufReader::new(TEST_V1_CAR);
 
     let car_reader = CarReader::new(buf_reader).await.unwrap();
-    let header = car_reader.header().clone();
+    let header = car_reader.header().unwrap().clone();
     let files: Vec<_> = car_reader.stream().try_collect().await.unwrap();
     assert_eq!(files.len(), 35);
 
@@ -37,10 +37,10 @@ async fn roundtrip_carv1_basic_fixtures_file() {
     let buf_reader = BufReader::new(CAR_V1_BASIC);
 
     let car_reader = CarReader::new(buf_reader).await.unwrap();
-    let header = car_reader.header().clone();
+    let header = car_reader.header().unwrap().clone();
 
     assert_eq!(
-        car_reader.header().roots(),
+        car_reader.header().unwrap().roots(),
         [
             "bafyreihyrpefhacm6kkp4ql6j6udakdit7g3dmkzfriqfykhjw6cad5lrm"
                 .parse()


### PR DESCRIPTION
This PR introduces a breaking API change from iroh-car in order to allow for the serialization/deserialization of arbitrary metadata in CAR headers.

See:

- https://github.com/n0-computer/iroh-car/issues/44
- https://github.com/darobin/dasl.ing/issues/32

## Motivation

The choice of dag-cbor map for CAR headers allows for the possibility of open-ended metadata in CAR headers, similar to the role headers play in HTTP or email. The [DASL CAR spec](https://dasl.ing/car.html
) makes this metadata support explicit.

## Implementation

[iroh-car](https://crates.io/crates/iroh-car) uses [serde_ipld_dag_cbor](https://crates.io/crates/serde_ipld_dagcbor/0.6.3) to parse the CAR header, which uses [cbor4ii](https://crates.io/crates/cbor4ii/0.2.14). cbor4ii is focused on zero-copy perf and doesn't expose a general Value type modeling the CBOR data model. Instead, it focuses on allowing you to serialize/deserialize from fixed types.

Since there is no intermediate representation of the CBOR, the minimally invasive path to supporting open-ended metadata in CAR headers is saving the literal header byte string on the CarReader struct, and providing methods to deserialize headers on-demand with Serde.

This makes a few small but breaking changes to the API:

- `CarReader.header()` returns a result, since it is now deserialized on-demand
- `CarWriter` needs an additional type parameter to allow for arbitrary serializable headers

In addition, a new method `CarReader.deserialize_header()` allows deserializing arbitrary Serde data types from the header byte slice.

The library does not do any hand-holding w/r/t forcing you to serialize valid CAR header shapes. However, if you use the `CarHeader` struct as before, it will always serialize to a valid header.

### Alternatives

I looked at using cborium or dcbor, both of which expose a Value enum type, but there was a lot of yak shaving involved.